### PR TITLE
Initial Project README, Contributing Guide, and License

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,32 @@
+# Contributing to ddd-linter
+
+We’re thrilled you’re interested in contributing to `ddd-linter`! This project is in early stages, and we welcome input from a wide range of disciplines—software developers, domain experts, DDD practitioners, and telemarketers alike. Wait no. And toolmakers alike.
+
+## Ways to Contribute
+
+- Propose glossary formats or improvements
+- Submit bug reports or usability improvements
+- Improve the static linter (linter-core)
+- Extend the extractor framework (extractor-core)
+- Experiment with AI integrations (ai-extractor)
+- Improve documentation and examples
+
+## Project Philosophy
+
+This project is based on the belief that:
+- Language matters in software
+- Shared understanding requires constant refinement
+- Automation can help—but must be modular, explainable, and respectful of human judgment
+
+## Getting Started
+
+1. Fork this repository and clone it locally
+2. Create a branch: `git checkout -b my-feature`
+3. Make your changes and commit with descriptive messages
+4. Push to your fork and open a pull request
+
+Make sure to lint and type-check your code before submitting:
+```bash
+npm run lint
+npm run typecheck
+

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 ddd-linter contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the “Software”), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is furnished
+to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,2 +1,52 @@
 # ddd-linter
-Core component to linting files with a Domain Driven Design glossary
+
+**Align your code with your domain language.**
+
+`ddd-linter` is an open-source tool that helps Domain-Driven Design (DDD) teams maintain alignment between the **ubiquitous language** defined in their bounded contexts and the terminology used in their code.
+
+This project is built on the insight that DDD is not just about modeling -- it’s about communication. And communication works best when the language we use is consistent, intentional, and shared.
+
+
+## Why this project?
+
+We’re building a feedback loop between two complementary kinds of analysis:
+
+- A **code linter** that checks whether code reflects the current domain language, flagging mismatches and gaps.
+- A **meaning extractor** that proposes glossary updates based on how teams actually speak and write—in documentation, Slack, meetings, and beyond.
+
+These are two halves of a continuous refinement cycle:
+
+- 🔍 **The linter** ensures code conforms to the documented language.
+- 🧠 **The extractor** helps evolve the language based on how it’s really used.
+
+To keep things modular and extensible, we are separating these responsibilities into cleanly defined packages.
+
+## Project Structure
+
+```
+ddd-linter/
+├── src/
+│   ├── linter-core/          # Static glossary vs. code linter (AST-based)
+│   ├── extractor-core/       # Interfaces & utilities for multi-source meaning extraction
+│   └── ai-extractor/         # Claude/OpenAI integration
+├── docs/                     # Architecture decision records, etc.
+```
+
+
+## Getting Started
+
+### 1. Create a Glossary
+
+Create a glossary file using the format defined by [Contextive](https://docs.contextive.tech/community/guides/defining-terminology/)
+
+## Philosophy
+
+This tool is not about enforcing correctness through rigid rules. It’s about enabling shared understanding and continuous learning through lightweight, practical feedback loops.
+
+## Contributing
+
+We welcome contributions from developers, modelers, and domain experts. See [CONTRIBUTING.md] for how to get involved.
+
+## License
+
+MIT — see [LICENSE]


### PR DESCRIPTION
This pull request adds the first important files for the ddd-linter project:

* A README.md that explains what the project is, how it works, and why we're building it

* A CONTRIBUTING.md with simple instructions for anyone who wants to help out

* A LICENSE file using the MIT license so it’s clear this is an open source project

This project is about helping teams keep their code and domain language in sync. The README also explains how the project is split into two parts: one that checks your code against your glossary, and one that helps you improve the glossary based on how people really talk and write.

There’s no working code in this pull request, just the files we need to get started and welcome new contributors.